### PR TITLE
Disallow duplicates in Servers

### DIFF
--- a/src/main/java/de/voidtech/gerald/entities/Server.java
+++ b/src/main/java/de/voidtech/gerald/entities/Server.java
@@ -24,7 +24,7 @@ public class Server
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long id;
 	
-	@Column
+	@Column(unique = true)
 	private String guildID;
 	
 	//TODO: Don't fetch EAGER for this.


### PR DESCRIPTION
Duplicate values of the guildId could be found, this will prevent it on the future
Will try to write a migration to delete any duplicates